### PR TITLE
Fix wrong token for in gradle upgrader pipeline

### DIFF
--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -24,4 +24,4 @@ jobs:
         # diff.
         uses: gradle-update/update-gradle-wrapper-action@981c551b17dbcf1940b1b4435afdb79babb7c13a
         with:
-          repo-token: ${{ secrets.GH_ACTIONS_PAT }}
+          repo-token: ${{ secrets.REVIEWER_GITHUB_TOKEN }}


### PR DESCRIPTION


# Purpose

This commit fixes a wrong token name that was set in the Gradle wrapper scheduler CI pipeline.

# Types of changes

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

# Checklist

- [ ] Documentation is updated
- [x] No new tests are needed
