### PR TITLE
Migrate to Gradle version catalog (Closes #30)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,12 +4,11 @@ plugins {
     id("spring-boot-app-template.java-conventions")
     id("spring-boot-app-template.code-metrics")
     id("spring-boot-app-template.publishing-conventions")
-    id("com.diffplug.spotless") version "6.19.0" apply true
-    id("org.springframework.boot") version "3.1.0" apply false
-    id("io.spring.dependency-management") version "1.1.0" apply false
-    val kotlinVersion = "1.8.22"
-    kotlin("jvm") version kotlinVersion apply false
-    kotlin("plugin.spring") version kotlinVersion apply false
+    id("com.diffplug.spotless") version libs.versions.spotless apply true
+    id("org.springframework.boot") version libs.versions.springboot apply false
+    id("io.spring.dependency-management") version libs.versions.spring.dependency.management apply false
+    kotlin("jvm") version libs.versions.kotlin apply false
+    kotlin("plugin.spring") version libs.versions.kotlin apply false
 }
 
 subprojects {

--- a/buildSrc/src/main/groovy/spring-boot-app-template.code-metrics.gradle
+++ b/buildSrc/src/main/groovy/spring-boot-app-template.code-metrics.gradle
@@ -22,7 +22,7 @@ spotless {
 }
 
 pmd {
-    toolVersion = "6.42.0"
+    toolVersion = libs.versions.pwd
     reportsDir = file("$project.buildDir/reports/pmd")
     ruleSets = []
     ruleSetFiles = files("config/pmd/ruleset.xml")

--- a/buildSrc/src/main/groovy/spring-boot-app-template.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/spring-boot-app-template.java-conventions.gradle
@@ -7,7 +7,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(17))
+        languageVersion.set(JavaLanguageVersion.of(libs.versions.jvmTarget.get()))
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,50 @@
+[versions]
+
+coroutines = "1.7.1"
+jacoco = "0.8.7"
+jvmTarget = "17"
+kotlin = "1.8.22"
+mockk = "1.13.5"
+mockkSpring = "4.0.2"
+pwd = "6.42.0"
+spotless = "6.19.0"
+spring_dependency_management = "1.1.0"
+springboot = "3.1.0"
+
+[libraries]
+
+# Kotlin & Coroutines
+kotlin_core = { module = "org.jetbrains.kotlin:kotlin-stdlib" }
+kotlin_jackson_module = { module = "com.fasterxml.jackson.module:jackson-module-kotlin" }
+kotlin_reflection = { module = "org.jetbrains.kotlin:kotlin-reflect" }
+kotlinx_coroutines_core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
+kotlinx_coroutines_reactor = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-reactor", version.ref = "coroutines" }
+kotlinx_coroutines_test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
+
+# Spring Boot
+springboot_actuator_starter = { module = "org.springframework.boot:spring-boot-starter-actuator" }
+springboot_test_starter = { module = "org.springframework.boot:spring-boot-starter-test" }
+springboot_validation_starter = { module = "org.springframework.boot:spring-boot-starter-validation" }
+springboot_web_starter = { module = "org.springframework.boot:spring-boot-starter-web" }
+
+# Testing
+mockk_core = { module = "io.mockk:mockk", version.ref = "mockk" }
+mockk_spring = { module = "com.ninja-squad:springmockk", version.ref = "mockkSpring" }
+
+[bundles]
+
+kotlin_all = [
+    "kotlin_core",
+    "kotlin_jackson_module",
+    "kotlin_reflection",
+    "kotlinx_coroutines_core",
+    "kotlinx_coroutines_reactor",
+    "kotlinx_coroutines_test",
+]
+
+springboot_all = [
+    "springboot_actuator_starter",
+    "springboot_test_starter",
+    "springboot_validation_starter",
+    "springboot_web_starter",
+]

--- a/spring-boot-app-template/build.gradle.kts
+++ b/spring-boot-app-template/build.gradle.kts
@@ -9,28 +9,21 @@ plugins {
 
 kotlin {
     jvmToolchain {
-        languageVersion.set(JavaLanguageVersion.of(17))
-        target { JavaLanguageVersion.of(17) }
+        languageVersion.set(JavaLanguageVersion.of(libs.versions.jvmTarget.get()))
+        target { JavaLanguageVersion.of(libs.versions.jvmTarget.get()) }
     }
 }
 
-val coroutinesVersion = "1.6.4"
-val mockkVersion = "1.13.2"
-val mockkSpringVersion = "3.1.1"
-
 dependencies {
     // Spring Boot
-    implementation("org.springframework.boot:spring-boot-starter-web")
-    implementation("org.springframework.boot:spring-boot-starter-validation")
-    implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation(libs.bundles.springboot.all)
 
     // Kotlin
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
-    implementation("org.jetbrains.kotlin:kotlin-reflect")
-    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
+    implementation(libs.bundles.kotlin.all)
 
     // Tests
-    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation(libs.mockk.core)
+    testImplementation(libs.mockk.spring)
 }
 
 tasks {
@@ -50,7 +43,7 @@ tasks {
     }
 
     jacoco {
-        toolVersion = "0.8.7"
+        toolVersion = libs.versions.jacoco.get()
     }
 
     jacocoTestReport {
@@ -61,7 +54,10 @@ tasks {
     }
 }
 
-tasks.findByName("spotlessKotlin")?.dependsOn("compileKotlin")
-tasks.findByName("spotlessKotlin")?.dependsOn("compileTestKotlin")
-tasks.findByName("spotlessKotlin")?.dependsOn("test")
-tasks.findByName("spotlessKotlin")?.dependsOn("jacocoTestReport")
+val tasksDependencies = mapOf(
+    "spotlessKotlin" to listOf("compileKotlin", "compileTestKotlin", "test", "jacocoTestReport")
+)
+
+tasksDependencies.forEach { (taskName, dependencies) ->
+    tasks.findByName(taskName)?.dependsOn(dependencies)
+}


### PR DESCRIPTION


# Purpose

This commit migrates the dependencies management to Gradle Catalog, so it's easier to handle all versions, and import bundles of well-known and used dependencies (e.g. Kotlin or Spring Boot)

# Types of changes

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring

# Checklist

- [ ] Documentation is updated
- [x] No new tests are needed
