### PR TITLE
Add liveness & readiness probs (Closes #130)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ The template is a working application with a minimal setup. It contains:
 - Integration with PostgreSQL, Flyway & Jooq
 - Integration with test containers
 - integration with [CodeQL](https://github.com/yonatankarp/spring-boot-app-template/security/code-scanning)
+- health check, readiness & liveness probs for k8s integration
+
 - MIT license and contribution information
 
 ## Setup

--- a/spring-boot-app-template/src/main/resources/application.yml
+++ b/spring-boot-app-template/src/main/resources/application.yml
@@ -1,6 +1,36 @@
 server:
   port: 8080
 
+management:
+  server:
+    port: ${server.port}
+  endpoints:
+    web:
+      exposure:
+        include:
+          - metrics
+          - metrics-requiredMetricName
+          - prometheus
+          - loggers
+          - health
+          - httptrace
+  endpoint:
+    health:
+      probes.enabled: true
+      show-details: always
+      livenessState.enabled: true
+      readinessState.enabled: true
+    metrics.enabled: true
+    prometheus.enabled: true
+    metrics:
+      export.prometheus.enabled: true
+      distribution:
+        percentiles-histogram.http.server:
+          requests: true
+        sla.http.server.requests: 50ms, 100ms, 200ms, 400ms
+        percentiles.http.server:
+          requests: 0.5, 0.9, 0.95, 0.99, 0.999
+
 spring:
   application:
     name: spring-boot-app-template


### PR DESCRIPTION


# Purpose

This commit adds the liveness & readiness probs to this repository so later on if/when it would be integrated with k8s this service can be checked for how healthy the pod is

# Types of changes

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring

# Checklist

- [x] Documentation is updated
- [x] No new tests are needed
