### PR TITLE
Migrate plugins to version catalog

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,15 +1,15 @@
 plugins {
-    id("com.diffplug.spotless") version libs.versions.spotless apply true
-    id("com.revolut.jooq-docker") version libs.versions.jooq.docker.plugin apply false
-    id("io.spring.dependency-management") version libs.versions.spring.dependency.management apply false
     id("jacoco")
-    id("org.openapi.generator") version libs.versions.swagger apply false
-    id("org.springframework.boot") version libs.versions.springboot apply false
     id("spring-boot-app-template.code-metrics")
     id("spring-boot-app-template.java-conventions")
     id("spring-boot-app-template.publishing-conventions")
-    kotlin("jvm") version libs.versions.kotlin apply false
-    kotlin("plugin.spring") version libs.versions.kotlin apply false
+    alias(libs.plugins.spotless) apply true
+    alias(libs.plugins.kotlin.jvm) apply false
+    alias(libs.plugins.kotlin.spring) apply false
+    alias(libs.plugins.springboot.dependency.management) apply false
+    alias(libs.plugins.springboot) apply false
+    alias(libs.plugins.openapi.generator) apply false
+    alias(libs.plugins.jooq) apply false
 }
 
 subprojects {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,17 +1,14 @@
 [versions]
 
 coroutines = "1.7.3"
-jacoco = "0.8.7"
-jooq = "0.9.15"
-jooq_docker_plugin = "0.3.9"
+jooqDockerPlugin = "0.3.9"
 jvmTarget = "17"
 kotlin = "1.8.22"
 mockk = "1.13.7"
 mockkSpring = "4.0.2"
 postgres = "42.6.0"
-pwd = "6.42.0"
 spotless = "6.19.0"
-spring_dependency_management = "1.1.0"
+springDependencyManagement = "1.1.0"
 springboot = "3.1.0"
 springdoc = "2.2.0"
 swagger = "6.6.0"
@@ -44,8 +41,19 @@ postgresql = { module = "org.postgresql:postgresql", version.ref = "postgres" }
 # Testing
 mockk_core = { module = "io.mockk:mockk", version.ref = "mockk" }
 mockk_spring = { module = "com.ninja-squad:springmockk", version.ref = "mockkSpring" }
-testcontainers_jupiter = { module = "org.testcontainers:junit-jupiter", version.ref = "testcontainers" }
-testcontainers_postgres = { module = "org.testcontainers:postgresql", version.ref = "testcontainers" }
+testcontainers_bom = { module = "org.testcontainers:testcontainers-bom", version.ref = "testcontainers" }
+testcontainers_jupiter = { module = "org.testcontainers:junit-jupiter"}
+testcontainers_postgres = { module = "org.testcontainers:postgresql" }
+
+[plugins]
+
+jooq = { id = "com.revolut.jooq-docker", version.ref = "jooqDockerPlugin" }
+kotlin_jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+kotlin_spring = { id = "org.jetbrains.kotlin.plugin.spring", version.ref = "kotlin" }
+openapi_generator = { id = "org.openapi.generator", version.ref = "swagger" }
+spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
+springboot = { id = "org.springframework.boot", version.ref = "springboot" }
+springboot_dependency_management = { id = "io.spring.dependency-management", version.ref = "springDependencyManagement" }
 
 [bundles]
 

--- a/spring-boot-app-template/build.gradle.kts
+++ b/spring-boot-app-template/build.gradle.kts
@@ -1,14 +1,14 @@
 import org.openapitools.generator.gradle.plugin.tasks.GenerateTask as GenerateOpenApiTask
 
 plugins {
-    id("com.revolut.jooq-docker")
-    id("io.spring.dependency-management")
     id("jacoco")
-    id("org.openapi.generator")
-    id("org.springframework.boot")
     id("spring-boot-app-template.code-metrics")
-    kotlin("jvm")
-    kotlin("plugin.spring")
+    alias(libs.plugins.jooq)
+    alias(libs.plugins.springboot.dependency.management)
+    alias(libs.plugins.openapi.generator)
+    alias(libs.plugins.springboot)
+    alias(libs.plugins.kotlin.jvm) apply true
+    alias(libs.plugins.kotlin.spring) apply true
 }
 
 kotlin {
@@ -36,17 +36,10 @@ dependencies {
     // Tests
     testImplementation(libs.mockk.core)
     testImplementation(libs.mockk.spring)
-
+    testImplementation(platform(libs.testcontainers.bom))
     testImplementation(libs.testcontainers.jupiter)
     testImplementation(libs.testcontainers.postgres)
 }
-
-dependencyManagement {
-    imports {
-        mavenBom("org.testcontainers:testcontainers-bom:${libs.versions.testcontainers.get()}")
-    }
-}
-
 
 tasks {
     getByName<Jar>("jar") {
@@ -61,10 +54,6 @@ tasks {
         useJUnitPlatform()
         finalizedBy(spotlessApply)
         finalizedBy(jacocoTestReport)
-    }
-
-    jacoco {
-        toolVersion = libs.versions.jacoco.get()
     }
 
     jacocoTestReport {
@@ -88,7 +77,7 @@ tasksDependencies.forEach { (taskName, dependencies) ->
 /********************************************/
 
 val apiDirectoryPath = "$projectDir/src/main/resources/api"
-val openApiGenerateOutputDir = "$buildDir/generated/openapi"
+val openApiGenerateOutputDir = "${layout.buildDirectory.get()}/generated/openapi"
 
 data class ApiSpec(
     val name: String,


### PR DESCRIPTION


# Purpose

This PR moves all plugin versions to the version catalog so dependabot can find them and upgrade them

# Types of changes

- [x] Bugfix
- [ ] Feature
- [x] Refactoring

# Checklist

- [ ] Documentation is updated
- [x] No new tests are needed
