### PR TITLE
Extract tests into a bundle

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -63,14 +63,12 @@ kotlin_all = [
     "kotlin_reflection",
     "kotlinx_coroutines_core",
     "kotlinx_coroutines_reactor",
-    "kotlinx_coroutines_test",
 ]
 
 springboot_all = [
     "springboot_actuator_starter",
     "springboot_jdbc_starter",
     "springboot_jooq_starter",
-    "springboot_test_starter",
     "springboot_validation_starter",
     "springboot_web_starter",
 ]
@@ -78,4 +76,13 @@ springboot_all = [
 persistence_support_all = [
     "flyway_core",
     "hikaricp_core",
+]
+
+test_all = [
+    "kotlinx_coroutines_test",
+    "mockk_core",
+    "mockk_spring",
+    "springboot_test_starter",
+    "testcontainers_jupiter",
+    "testcontainers_postgres",
 ]

--- a/spring-boot-app-template/build.gradle.kts
+++ b/spring-boot-app-template/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.openapitools.generator.gradle.plugin.tasks.GenerateTask as GenerateOpenApiTask
 
 plugins {
-    id("jacoco")
+    jacoco
     id("spring-boot-app-template.code-metrics")
     alias(libs.plugins.jooq)
     alias(libs.plugins.springboot.dependency.management)
@@ -34,15 +34,12 @@ dependencies {
     implementation(libs.springdoc.openapi.starter)
 
     // Tests
-    testImplementation(libs.mockk.core)
-    testImplementation(libs.mockk.spring)
     testImplementation(platform(libs.testcontainers.bom))
-    testImplementation(libs.testcontainers.jupiter)
-    testImplementation(libs.testcontainers.postgres)
+    testImplementation(libs.bundles.test.all)
 }
 
 tasks {
-    getByName<Jar>("jar") {
+    jar {
         enabled = false
     }
 
@@ -50,7 +47,7 @@ tasks {
         finalizedBy(spotlessApply)
     }
 
-    withType<Test> {
+    test {
         useJUnitPlatform()
         finalizedBy(spotlessApply)
         finalizedBy(jacocoTestReport)


### PR DESCRIPTION


# Purpose

This commit extracts the test dependencies into a bundle and creates a new test_all bundle so that all test dependencies are only part of `testImplementation` scope and not `implementation` scope.

# Types of changes

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring

# Checklist

- [ ] Documentation is updated
- [x] No new tests are needed
