### PR TITLE
Remove `pull_request_target`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,6 @@ name: Continuous Integration
 on:
   pull_request:
     types: [ opened, synchronize, reopened, ready_for_review ]
-  pull_request_target:
-    types: [ opened, synchronize, reopened, ready_for_review ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.job }}-${{ github.ref }}


### PR DESCRIPTION

# Purpose

This commit removes the pull_request_target from CI as it's not required anymore

# Types of changes

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring

# Checklist

- [ ] Documentation is updated
- [x] No new tests are needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow triggers to stop responding to pull_request_target events.
  * CI will continue to run on standard pull_request events (opened, synchronize, reopened, ready for review).
  * No changes to application functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->