### PR TITLE
Switch to fully reactive stack: WebFlux + R2DBC

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     container_name: spring-starter-postgres
     networks:
       - proxynet
-    image: postgres:14
+    image: postgres:18-alpine
     restart: always
     environment:
       POSTGRES_USER: "postgres"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,17 +26,18 @@ kotlinx_coroutines_test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-t
 
 # Spring Boot
 springboot_actuator_starter = { module = "org.springframework.boot:spring-boot-starter-actuator" }
-springboot_jdbc_starter = { module = "org.springframework.boot:spring-boot-starter-jdbc" }
-springboot_jooq_starter = { module = "org.springframework.boot:spring-boot-starter-jooq" }
+springboot_r2dbc_starter = { module = "org.springframework.boot:spring-boot-starter-data-r2dbc" }
 springboot_test_starter = { module = "org.springframework.boot:spring-boot-starter-test" }
 springboot_validation_starter = { module = "org.springframework.boot:spring-boot-starter-validation" }
 springboot_web_starter = { module = "org.springframework.boot:spring-boot-starter-webflux" }
-springdoc_openapi_starter = { module = "org.springdoc:springdoc-openapi-starter-webmvc-ui", version.ref = "springdoc" }
+springdoc_openapi_starter = { module = "org.springdoc:springdoc-openapi-starter-webflux-ui", version.ref = "springdoc" }
 
 # Persistence
 flyway_postgres = { module = "org.flywaydb:flyway-database-postgresql" }
-hikaricp_core = { module = "com.zaxxer:HikariCP" }
+jooq_core = { module = "org.jooq:jooq" }
+jooq_kotlin_coroutines = { module = "org.jooq:jooq-kotlin-coroutines" }
 postgresql = { module = "org.postgresql:postgresql", version.ref = "postgres" }
+r2dbc_postgresql = { module = "org.postgresql:r2dbc-postgresql" }
 
 # Testing
 mockk_core = { module = "io.mockk:mockk", version.ref = "mockk" }
@@ -67,15 +68,16 @@ kotlin_all = [
 
 springboot_all = [
     "springboot_actuator_starter",
-    "springboot_jdbc_starter",
-    "springboot_jooq_starter",
+    "springboot_r2dbc_starter",
     "springboot_validation_starter",
     "springboot_web_starter",
 ]
 
 persistence_support_all = [
     "flyway_postgres",
-    "hikaricp_core",
+    "jooq_core",
+    "jooq_kotlin_coroutines",
+    "r2dbc_postgresql",
 ]
 
 test_all = [

--- a/spring-starter/build.gradle.kts
+++ b/spring-starter/build.gradle.kts
@@ -69,6 +69,14 @@ tasks {
             html.required.set(true)
         }
     }
+
+    generateJooqClasses {
+        withContainer {
+            image {
+                name = "postgres:18-alpine"
+            }
+        }
+    }
 }
 
 val tasksDependencies = mapOf(

--- a/spring-starter/src/main/kotlin/com/yonatankarp/spring/starter/adapters/output/persistence/JooqConfig.kt
+++ b/spring-starter/src/main/kotlin/com/yonatankarp/spring/starter/adapters/output/persistence/JooqConfig.kt
@@ -1,0 +1,14 @@
+package com.yonatankarp.spring.starter.adapters.output.persistence
+
+import io.r2dbc.spi.ConnectionFactory
+import org.jooq.DSLContext
+import org.jooq.SQLDialect
+import org.jooq.impl.DSL
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class JooqConfig {
+    @Bean
+    fun dslContext(connectionFactory: ConnectionFactory): DSLContext = DSL.using(connectionFactory, SQLDialect.POSTGRES)
+}

--- a/spring-starter/src/main/resources/application.yml
+++ b/spring-starter/src/main/resources/application.yml
@@ -30,16 +30,26 @@ management:
         percentiles.http.server:
           requests: 0.5, 0.9, 0.95, 0.99, 0.999
 
+db:
+  host: ${DB_HOST:localhost}
+  port: ${DB_PORT:5432}
+  schema: ${DB_SCHEMA:spring-starter}
+  username: ${DB_USERNAME:postgres}
+  password: ${DB_PASSWORD:secret}
+  endpoint: "${db.host}:${db.port}/${db.schema}"
+
 spring:
   application:
     name: spring-starter
-  datasource:
-    url: "jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${DB_SCHEMA:spring-starter}"
-    username: ${DB_USERNAME:postgres}
-    password: ${DB_PASSWORD:secret}
-    driver-class-name: org.postgresql.Driver
+  r2dbc:
+    url: "r2dbc:postgresql://${db.endpoint}"
+    username: ${db.username}
+    password: ${db.password}
   flyway:
     enabled: true
+    url: "jdbc:postgresql://${db.endpoint}"
+    user: ${db.username}
+    password: ${db.password}
 
 springdoc:
   swagger-ui:

--- a/spring-starter/src/test/kotlin/com/yonatankarp/spring/starter/adapters/AbstractIntegrationTest.kt
+++ b/spring-starter/src/test/kotlin/com/yonatankarp/spring/starter/adapters/AbstractIntegrationTest.kt
@@ -8,15 +8,17 @@ import org.testcontainers.postgresql.PostgreSQLContainer
 abstract class AbstractIntegrationTest {
     companion object {
         @Container
-        private val postgreSQLContainer = PostgreSQLContainer("postgres:latest")
+        private val postgreSQLContainer = PostgreSQLContainer("postgres:18-alpine")
 
         @DynamicPropertySource
         @JvmStatic
         @Suppress("unused")
         fun registerDynamicProperties(registry: DynamicPropertyRegistry) {
-            registry.add("spring.datasource.url") { postgreSQLContainer.jdbcUrl }
-            registry.add("spring.datasource.username") { postgreSQLContainer.username }
-            registry.add("spring.datasource.password") { postgreSQLContainer.password }
+            registry.add("db.host") { postgreSQLContainer.host }
+            registry.add("db.port") { postgreSQLContainer.firstMappedPort }
+            registry.add("db.schema") { postgreSQLContainer.databaseName }
+            registry.add("db.username") { postgreSQLContainer.username }
+            registry.add("db.password") { postgreSQLContainer.password }
         }
     }
 }


### PR DESCRIPTION
## Summary

The template shipped with `spring-boot-starter-webflux` (reactive Netty) but blocking JDBC/jOOQ/Hikari underneath, which would block the Netty event loop on every DB call. This realigns the runtime to be fully reactive while keeping jOOQ's type-safe SQL + codegen.

## Changes

### Stack swap
- Drop `spring-boot-starter-jdbc`, `spring-boot-starter-jooq`, HikariCP.
- Add `spring-boot-starter-data-r2dbc` and `org.postgresql:r2dbc-postgresql`.
- Switch springdoc starter from `webmvc-ui` to `webflux-ui` (Spring's reactive variant).
- Keep jOOQ via R2DBC: explicit `org.jooq:jooq` + `org.jooq:jooq-kotlin-coroutines` for `Publisher` -> `suspend` bridging.
- `dev.monosoul.jooq-docker` codegen plugin stays (it uses JDBC at build time only, independent of runtime driver).

### `DSLContext` wiring
- Added `JooqConfig` `@Configuration` in `adapters/output/persistence/` that wires `DSLContext` manually from the R2DBC `ConnectionFactory` (since `spring-boot-starter-jooq`'s auto-config is gone).

### DB config sharing
- `application.yml` now has a `db.*` block with host/port/schema/credentials.
- `spring.r2dbc.url` and `spring.flyway.url` both reference `${db.endpoint}` and only differ in protocol prefix (`r2dbc:postgresql://` vs `jdbc:postgresql://`).
- Flyway keeps using JDBC for migrations (no R2DBC implementation exists).

### Tests
- `AbstractIntegrationTest` registers `db.*` dynamic properties from the testcontainer; both R2DBC runtime and Flyway pick them up automatically.

### Image alignment
- Pin testcontainer + codegen + compose Postgres images to `postgres:18-alpine` (was: `postgres:latest` in tests, `postgres:14.4-alpine` in codegen default, `postgres:14` in compose). Single image, single layer cached.

## Test plan

- [x] `./gradlew clean build` green (33s on cached image)
- [x] `ApplicationTest.context loads()` passes (Spring Boot 4.0.6 boots cleanly)
- [x] `ApplicationTest.smoke test()` passes (`DSLContext` bean wired from R2DBC `ConnectionFactory`)
- [x] R2DBC repository scanning runs (found 0 repositories, as expected)
- [x] Flyway runs migrations against the testcontainer via JDBC
- [ ] Spotless / linters pass in CI
- [ ] CodeQL passes in CI

## Out of scope for this PR

- Repo rename to `kotlin-spring-boot-template` + package rename (separate follow-up; will land after this merges).
- All other findings from the 2026-05-23 template audit (DDD/hex example refactor, Spotless behavior, CI triggers, dependabot policy, test pyramid, actuator config, layered Dockerfile, etc.) tracked separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PostgreSQL to version 18-alpine for improved performance and security.
  * Migrated database access from JDBC/HikariCP to R2DBC for non-blocking, reactive database operations.
  * Updated API documentation library to support reactive framework patterns.
  * Configured jOOQ for type-safe SQL query building with reactive support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yonatankarp/spring-starter/pull/437?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->