### PR TITLE
Restrict actuator endpoints + separate management to port 9001

### DIFF
--- a/spring-starter/Dockerfile
+++ b/spring-starter/Dockerfile
@@ -2,9 +2,10 @@ FROM eclipse-temurin:21-jre-alpine
 
 ENV APP_BASE="/home" \
     APP_NAME="spring-starter" \
-    SERVER_PORT="8080"
+    SERVER_PORT="8080" \
+    MANAGEMENT_PORT="9001"
 
-EXPOSE ${SERVER_PORT}
+EXPOSE ${SERVER_PORT} ${MANAGEMENT_PORT}
 
 RUN apk update && apk upgrade && apk add --no-cache curl openssl gcompat bash busybox-extras iputils
 

--- a/spring-starter/src/main/resources/application.yml
+++ b/spring-starter/src/main/resources/application.yml
@@ -1,9 +1,9 @@
 server:
-  port: 8080
+  port: ${SERVER_PORT:8080}
 
 management:
   server:
-    port: 9001
+    port: ${MANAGEMENT_PORT:9001}
   endpoints:
     web:
       exposure:

--- a/spring-starter/src/main/resources/application.yml
+++ b/spring-starter/src/main/resources/application.yml
@@ -3,20 +3,18 @@ server:
 
 management:
   server:
-    port: ${server.port}
+    port: 9001
   endpoints:
     web:
       exposure:
         include:
-          - metrics
-          - metrics-requiredMetricName
-          - prometheus
-          - loggers
           - health
+          - metrics
+          - prometheus
   endpoint:
     health:
       probes.enabled: true
-      show-details: always
+      show-details: when-authorized
       livenessState.enabled: true
       readinessState.enabled: true
     metrics.enabled: true


### PR DESCRIPTION
## Summary

Default actuator config exposed runtime-mutation and info-leak endpoints on the public port. Three real footguns:

1. `management.server.port: \${server.port}` — actuator co-located with the public API. Should be on an internal/ops network.
2. `loggers` exposed — runtime log-level changes via POST on the public port.
3. `health.show-details: always` — leaks disk paths, JVM internals, threadpool stats to anonymous callers.
4. `metrics-requiredMetricName` — not a real Spring Boot endpoint, leftover from a copy-paste.

## Changes

### `application.yml`

- Management port → `9001` (separate from public `8080`).
- Exposed endpoints → `health`, `metrics`, `prometheus` only.
- `show-details: when-authorized` (was `always`).
- Dropped `loggers` and the typo'd `metrics-requiredMetricName`.

### `Dockerfile`

- Added `MANAGEMENT_PORT=9001` env + `EXPOSE 8080 9001` so the management port is reachable when the image is deployed.

## Test plan

- [x] `./gradlew clean test` green (26/26 tests pass)
- [x] `@SpringBootTest(RANDOM_PORT)` auto-randomizes both ports — no parallel-test conflicts on hardcoded 9001
- [ ] Manual: `curl localhost:9001/actuator/health` returns `{\"status\":\"UP\"}` (running locally to verify)

## Out of scope

- Wiring authentication on `when-authorized` health details — depends on a real auth setup that each derived project chooses.
- Network segmentation (the actual 'don't expose 9001 publicly' is a deployment concern: ingress/k8s NetworkPolicy/etc).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated management port for monitoring (9001).
  * Exposed health, metrics, and Prometheus endpoints for application monitoring.

* **Chores**
  * Container now exposes both application and management ports; ports are configurable via environment.
  * Health endpoint details are restricted to authorized access only.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yonatankarp/spring-starter/pull/441?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->