### PR TITLE
Trigger build workflow on push to main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,9 @@ name: Continuous Integration
 on:
   pull_request:
     types: [ opened, synchronize, reopened, ready_for_review ]
+  push:
+    branches:
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary

Previously the build workflow ran only on PRs — nothing verified main post-merge. A merge can produce a broken main even when every individual PR was green (two PRs touching overlapping config, dependency conflicts that only surface when both are present, etc). Adding `push: branches: [main]` runs the pipeline + linters against the merged state so regressions surface immediately instead of being discovered by the next PR's CI run.

## Changes

- `.github/workflows/build.yml`: added `push: branches: [main]` alongside the existing `pull_request` trigger.

## Behavior notes

- `dependabot_auto_merge` job is gated by `if: github.actor == 'dependabot[bot]'`, so on push events it silently skips (push events set `github.actor` to the merger, not the bot).
- Concurrency group `\${{ github.workflow }}-\${{ github.ref }}` separates PR refs (`refs/pull/X/merge`) from main (`refs/heads/main`), so push-to-main runs don't fight with in-flight PR runs.

## Test plan

- [ ] Merge this PR; verify the workflow runs once on the merge commit
- [ ] Open a new PR; verify the workflow still runs on the PR ref (and that the push-to-main run from the prior merge doesn't get cancelled)

## Out of scope

- #18 (CodeQL on PRs) is moot since CodeQL was removed in #443.