### PR TITLE
Multi-stage layered Dockerfile

### DIFF
--- a/spring-starter/Dockerfile
+++ b/spring-starter/Dockerfile
@@ -1,3 +1,12 @@
+FROM eclipse-temurin:25-jdk-alpine AS extractor
+
+ENV APP_NAME="spring-starter"
+WORKDIR /workspace
+
+COPY ${APP_NAME}/build/libs/${APP_NAME}*.jar application.jar
+RUN java -Djarmode=tools -jar application.jar extract --layers --destination extracted
+
+
 FROM eclipse-temurin:25-jre-alpine
 
 ENV APP_BASE="/home" \
@@ -9,12 +18,13 @@ EXPOSE ${SERVER_PORT} ${MANAGEMENT_PORT}
 
 RUN apk update && apk upgrade && apk add --no-cache curl openssl gcompat bash busybox-extras iputils
 
-RUN mkdir -p ${APP_BASE}/${APP_NAME}
+WORKDIR ${APP_BASE}/${APP_NAME}
 
-COPY ${APP_NAME}/build/libs/${APP_NAME}*.jar ${APP_BASE}/${APP_NAME}.jar
+COPY --from=extractor /workspace/extracted/dependencies/ ./
+COPY --from=extractor /workspace/extracted/spring-boot-loader/ ./
+COPY --from=extractor /workspace/extracted/snapshot-dependencies/ ./
+COPY --from=extractor /workspace/extracted/application/ ./
 
-# Running the image as 'nobody' user
-# https://stackoverflow.com/questions/72562483/is-it-safe-to-run-openjdk-images-like-eclipse-temurin-as-root
 USER 65534
 
-CMD java -jar ${APP_BASE}/${APP_NAME}.jar
+ENTRYPOINT ["java", "-jar", "application.jar"]


### PR DESCRIPTION
## Summary

Previously the Dockerfile shipped the whole Spring Boot fat-jar as a single Docker layer. Every code change re-pushed the full ~65MB image, even when only `application/` classes changed.

Switched to Spring Boot's layered jar format via `java -Djarmode=tools extract --layers`. Two stages — an `extractor` stage (JDK image) splits the fat-jar into 4 layer directories; the runtime stage (JRE image) copies each separately in stability order so Docker's layer cache wins on code-only changes.

## Layer sizes after this change

| Layer | Size | Changes |
|---|---|---|
| `dependencies/` | **64.3 MB** | When `libs.versions.toml` changes |
| `spring-boot-loader/` | 4.1 KB | (bundled in app.jar with the new format) |
| `snapshot-dependencies/` | 4.1 KB | (empty — no SNAPSHOT deps) |
| **`application/`** | **77.8 KB** | Every code commit |

Result: code-only commits ship ~78 KB instead of 65 MB.

## Notes on the format

`jarmode=tools` (Spring Boot 3.2+) produces a different layout than the older `jarmode=layertools`. The `application/` layer contains a launcher jar (`application.jar`) with a `Class-Path` MANIFEST pointing at `lib/` (sibling, supplied by `dependencies/`). ENTRYPOINT is `["java", "-jar", "application.jar"]` — the launcher handles loading the library jars internally.

## Test plan

- [x] `docker build` succeeds
- [x] `docker run` boots cleanly; container reaches "Started Application"
- [x] `curl localhost:8080/greetings/random` returns a valid greeting
- [x] `curl localhost:9001/actuator/health` returns `{"status":"UP"}`
- [x] Layer sizes verified via `docker image history`