### PR TITLE
Migrate CI workflows to github-actions@v2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,13 +13,19 @@ concurrency:
 
 jobs:
   pipeline:
+    permissions:
+      contents: read
+      pull-requests: write
+      checks: write
     strategy:
       fail-fast: false
       matrix:
         service: [ kotlin-spring-boot-template ]
-    uses: yonatankarp/github-actions/.github/workflows/ci.yml@v1
+    uses: yonatankarp/github-actions/.github/workflows/ci.yml@v2
     with:
-      app_name: ${{ matrix.service }}
+      image-name: ${{ matrix.service }}
+      dockerfile-path: ${{ matrix.service }}/Dockerfile
+      gradle-module: ":${{ matrix.service }}"
 
   dependabot_auto_merge:
     needs: pipeline
@@ -27,9 +33,9 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: yonatankarp/github-actions/.github/workflows/dependabot-auto-merge.yml@v1
+    uses: yonatankarp/github-actions/.github/workflows/dependabot-auto-merge.yml@v2
     secrets:
       GITHUB_PAT: ${{ secrets.REVIEWER_GITHUB_TOKEN }}
 
   linters:
-    uses: yonatankarp/github-actions/.github/workflows/linters.yml@v1
+    uses: yonatankarp/github-actions/.github/workflows/linters.yml@v2


### PR DESCRIPTION
## Summary
Migrates this repo from `yonatankarp/github-actions@v1` to `@v2`. v1 stays frozen at the old commit; nothing about the existing pipeline behavior changes here beyond input renames + permission grants.

## What changes
- `ci.yml@v1` → `@v2`. Input renames: `app_name` → `image-name`. Added `dockerfile-path` and `gradle-module` (both were implicit under v1's overloaded `context` input).
- `dependabot-auto-merge.yml@v1` → `@v2`. v2 fixes the silent string-vs-boolean bug in the auto-tag-move step.
- `linters.yml@v1` → `@v2`. v2 drops `continue-on-error` on the lint steps so spotless + markdown-lint actually gate now; bundles a default markdown-lint config.
- **New permissions** on the pipeline job: `pull-requests: write` and `checks: write` — v2's `publish-test-reports` step (default on) needs these.

## Test plan
- [ ] CI runs green
- [ ] Test results published as a check
- [ ] Docker build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)