### PR TITLE
Drop local markdown-lint rules.json — use v2 bundled default

### DIFF
--- a/config/markdown-lint/rules.json
+++ b/config/markdown-lint/rules.json
@@ -1,7 +1,0 @@
-{
-  "MD013": {
-    "line_length": 80,
-    "code_block_line_length": 120,
-    "tables": false
-  }
-}


### PR DESCRIPTION
## Summary
- The local `config/markdown-lint/rules.json` is byte-identical to the bundled default at `yonatankarp/github-actions/v2/config/markdown-lint/rules.json`, which the v2 linters workflow auto-fetches when no override is passed.
- Removing the duplicate (and the now-empty `config/` directory) eliminates maintenance surface without changing lint behavior.

## Test plan
- [ ] CI green on this PR — confirms the v2 linters workflow successfully resolves the bundled config and lints the existing markdown without regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)